### PR TITLE
fix: Remove unused import

### DIFF
--- a/src/main/kotlin/com/mparticle/kits/RoktKit.kt
+++ b/src/main/kotlin/com/mparticle/kits/RoktKit.kt
@@ -11,7 +11,6 @@ import com.mparticle.MParticle
 import com.mparticle.MParticle.IdentityType
 import com.mparticle.commerce.CommerceEvent
 import com.mparticle.identity.MParticleUser
-import com.mparticle.internal.Constants
 import com.mparticle.internal.Logger
 import com.mparticle.kits.KitIntegration.CommerceListener
 import com.mparticle.kits.KitIntegration.IdentityListener


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Removed an import that was not being used in the code, cleaning up the codebase and preventing unnecessary warnings.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Tested with sample app

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/REPLACEME
