### PR TITLE
fix: Change method visibility from public to private

### DIFF
--- a/src/main/kotlin/com/mparticle/kits/RoktKit.kt
+++ b/src/main/kotlin/com/mparticle/kits/RoktKit.kt
@@ -199,7 +199,7 @@ class RoktKit : KitIntegration(), CommerceListener, IdentityListener, RoktListen
         )
     }
 
-    public fun mapToRoktConfig(config: RoktConfig): com.rokt.roktsdk.RoktConfig {
+    private fun mapToRoktConfig(config: RoktConfig): com.rokt.roktsdk.RoktConfig {
         val colorMode = when (config.colorMode) {
             RoktConfig.ColorMode.LIGHT -> com.rokt.roktsdk.RoktConfig.ColorMode.LIGHT
             RoktConfig.ColorMode.DARK -> com.rokt.roktsdk.RoktConfig.ColorMode.DARK


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Changed mapToRoktConfig method to private since it's only used within this class.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Tested with sample app.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/REPLACEME
