### PR TITLE
feat: Add support for the fontFilePathMap to roktkit

### DIFF
--- a/src/main/kotlin/com/mparticle/kits/RoktKit.kt
+++ b/src/main/kotlin/com/mparticle/kits/RoktKit.kt
@@ -20,6 +20,7 @@ import com.mparticle.kits.KitIntegration.IdentityListener
 import com.mparticle.kits.KitIntegration.RoktListener
 import com.mparticle.rokt.RoktConfig
 import com.mparticle.rokt.RoktEmbeddedView
+import com.mparticle.rokt.RoktOptions
 import com.rokt.roktsdk.CacheConfig
 import com.rokt.roktsdk.Rokt
 import com.rokt.roktsdk.Rokt.SdkFrameworkType.Android
@@ -62,13 +63,18 @@ class RoktKit : KitIntegration(), CommerceListener, IdentityListener, RoktListen
                     val info = manager.getPackageInfoForApp(context.packageName, 0)
                     val application = context.applicationContext as Application
                     val mparticleVersion = BuildConfig.VERSION_NAME
+                    
+                    // Get RoktOptions from the kit manager
+                    val roktOptions = kitManager?.roktOptions
+                    val fontFilePathMap = roktOptions?.fontFilePathMap ?: emptyMap()
+                    val fontPostScriptNames = roktOptions?.fontPostScriptNames ?: emptySet()
 
                     Rokt.init(
                         roktTagId = roktTagId,
                         appVersion = info.versionName,
                         application = application,
-                        fontPostScriptNames = emptySet(),
-                        fontFilePathMap = emptyMap(),
+                        fontPostScriptNames = fontPostScriptNames,
+                        fontFilePathMap = fontFilePathMap,
                         callback = null,
                         mParticleSdkVersion = mparticleVersion,
                         mParticleKitVersion = mparticleVersion


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - This PR adds support for configuring custom fonts in the Rokt Kit initialization.
It retrieves RoktOptions from the Kit Manager, allowing either fontFilePathMap or fontPostScriptNames to be passed to Rokt.init. These options enable clients to supply custom fonts from assets or pre-loaded Typeface objects when initializing Rokt through the mParticle SDK.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Tested with sample app.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7414
