### PR TITLE
feat: Handle emailsha256 and other before sending attributes to Rokt Kit

### DIFF
--- a/src/main/kotlin/com/mparticle/kits/RoktKit.kt
+++ b/src/main/kotlin/com/mparticle/kits/RoktKit.kt
@@ -324,11 +324,9 @@ class RoktKit : KitIntegration(), CommerceListener, IdentityListener, RoktListen
         if (attributes == null) return
 
         val emailKey = MParticle.IdentityType.Email.name.lowercase()
-        val otherKey = MParticle.IdentityType.Other.name.lowercase()
         val emailShaKey = "emailsha256"
 
         val emailShaValue = attributes.entries.find { it.key.equals(emailShaKey, ignoreCase = true) }?.value
-        val otherValue = attributes.entries.find { it.key.equals(otherKey, ignoreCase = true) }?.value
 
         when {
             !emailShaValue.isNullOrEmpty() -> {

--- a/src/test/kotlin/com/mparticle/kits/RoktKitTests.kt
+++ b/src/test/kotlin/com/mparticle/kits/RoktKitTests.kt
@@ -563,7 +563,8 @@ class RoktKitTests {
     fun TestverifyHashedEmail_removes_when_emailsha256_is_present() {
         val attributes = mutableMapOf(
             "email" to "user@example.com",
-            "emailsha256" to "hashed_email_value"
+            "emailsha256" to "hashed_email_value",
+            "other" to "Test"
         )
         val method: Method = RoktKit::class.java.getDeclaredMethod(
             "verifyHashedEmail",
@@ -575,6 +576,7 @@ class RoktKitTests {
 
         assertFalse(attributes.containsKey("email"))
         assertEquals("hashed_email_value", attributes["emailsha256"])
+        assertEquals("Test", attributes["other"])
     }
 
 


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - This PR includes logic to handle emailsha256 and other before passing attributes to the Rokt Kit:
 If emailsha256 is present, remove both email and other from the attributes.
 If other is present (and emailsha256 is not), map other to emailsha256, then remove both email and other.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Tested with sample app

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7556
