### PR TITLE
fix: viewname and compose compiler plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,6 @@ buildscript {
 plugins {
     id "org.sonarqube" version "3.5.0.2730"
     id "org.jlleitschuh.gradle.ktlint" version "11.2.0"
-    id "org.jetbrains.kotlin.plugin.compose" version "2.0.0"
 }
 
 sonarqube {
@@ -51,6 +50,9 @@ android {
     }
     buildFeatures {
         compose true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.2" // or match the app’s version
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:7.4.1'
         classpath 'com.mparticle:android-kit-plugin:' + project.version
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:2.0.0'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.0'
     }
 }
 
@@ -34,6 +34,7 @@ apply plugin: "kotlin-android"
 apply plugin: 'com.mparticle.kit'
 
 android {
+    namespace 'com.mparticle.kits.rokt'
     defaultConfig {
         minSdkVersion 21
         consumerProguardFiles 'consumer-proguard.pro'
@@ -52,7 +53,7 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.2" // or match the app’s version
+        kotlinCompilerExtensionVersion = "1.5.0"
     }
 }
 
@@ -62,18 +63,20 @@ repositories {
 }
 
 dependencies {
+    def composeBom = platform('androidx.compose:compose-bom:2023.10.01')
+    implementation composeBom
     implementation 'androidx.annotation:annotation:1.5.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4'
-    implementation 'androidx.compose.runtime:runtime-android:1.8.3'
+    implementation 'androidx.compose.runtime:runtime'
     api 'com.rokt:roktsdk:4.11.0'
 
     testImplementation  files('libs/java-json.jar')
     testImplementation 'com.squareup.assertj:assertj-android:1.2.0'
     testImplementation ("io.mockk:mockk:1.13.4")
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4'
-    compileOnly 'androidx.compose.ui:ui:1.0.0'
-    compileOnly 'androidx.compose.material:material:1.0.0'
-    compileOnly 'androidx.compose.ui:ui-tooling:1.0.0'
+    compileOnly 'androidx.compose.ui:ui'
+    compileOnly 'androidx.compose.material:material'
+    compileOnly 'androidx.compose.ui:ui-tooling'
 }
 
 ktlint {

--- a/src/main/kotlin/com/mparticle/kits/RoktLayout.kt
+++ b/src/main/kotlin/com/mparticle/kits/RoktLayout.kt
@@ -12,7 +12,7 @@ import com.rokt.roktsdk.Rokt
 @Suppress("FunctionName")
 fun RoktLayout(
     sdkTriggered: Boolean,
-    viewName: String,
+    identifier: String,
     attributes: Map<String, String>,
     location: String,
     modifier: Modifier = Modifier,
@@ -30,7 +30,7 @@ fun RoktLayout(
 
     resultMapState.value?.let { resultMap ->
         com.rokt.roktsdk.RoktLayout(
-            sdkTriggered, viewName, modifier, resultMap.attributes, location,
+            sdkTriggered, identifier, modifier, resultMap.attributes, location,
             onLoad = { resultMap.callback.onLoad() },
             onShouldShowLoadingIndicator = { resultMap.callback.onShouldShowLoadingIndicator() },
             onShouldHideLoadingIndicator = { resultMap.callback.onShouldHideLoadingIndicator() },


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Fixed the view name to align correctly with the selected placement.
 - Updated the Kotlin Compose compiler plugin version to be compatible with the current Kotlin and KtLint setup.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Tested with sample app.
 
 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/REPLACEME
