### PR TITLE
fix: Support mutable and immutable attributes in selectPlacement

### DIFF
--- a/src/main/kotlin/com/mparticle/kits/RoktLayout.kt
+++ b/src/main/kotlin/com/mparticle/kits/RoktLayout.kt
@@ -22,9 +22,12 @@ fun RoktLayout(
     val resultMapState = remember { mutableStateOf<RoktResult?>(null) }
     if (sdkTriggered) {
         LaunchedEffect(Unit) {
-            instance?.runComposableWithCallback(attributes, mpRoktEventCallback, { resultMap, callback ->
-                resultMapState.value = RoktResult(resultMap, callback)
-            })
+            instance?.runComposableWithCallback(
+                HashMap(attributes), mpRoktEventCallback,
+                { resultMap, callback ->
+                    resultMapState.value = RoktResult(resultMap, callback)
+                },
+            )
         }
     }
 


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Previously, selectPlacement assumed attributes were always mutable. When an immutable map was passed, it caused issues if modifications were required during processing.Created a shallow copy of attributes before passing it to runComposableWithCallback.This ensures compatibility with both immutable and mutable inputs.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Tested with sample app for both immutable and mutable inputs.
 
 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/REPLACEME
