### PR TITLE
chore: bump com.rokt:roktsdk from 4.14.0 to 4.14.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.5.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4'
     implementation 'androidx.compose.runtime:runtime'
-    api 'com.rokt:roktsdk:4.14.0'
+    api 'com.rokt:roktsdk:4.14.1'
 
     testImplementation  files('libs/java-json.jar')
     testImplementation 'com.squareup.assertj:assertj-android:1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.5.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4'
     implementation 'androidx.compose.runtime:runtime'
-    api 'com.rokt:roktsdk:4.14.1'
+    api 'com.rokt:roktsdk:4.14.2'
 
     testImplementation  files('libs/java-json.jar')
     testImplementation 'com.squareup.assertj:assertj-android:1.2.0'


### PR DESCRIPTION
## Background

- Bumps the Rokt SDK dependency from `4.14.0` to `4.14.2` to pick up the latest patch release.

## What Has Changed

- Updated `com.rokt:roktsdk` from `4.14.0` to `4.14.2` in `build.gradle`.

## Checklist

- [x] Self-review completed
- [ ] Tests added or updated
- [ ] Tested locally